### PR TITLE
Detect Leaflet in local scope

### DIFF
--- a/leaflet.geojsoncss.js
+++ b/leaflet.geojsoncss.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 (function (window, document, undefined) {
-	if ( !window.L || !L.GeoJSON ) {
+	if ( typeof L === 'undefined' || !L.GeoJSON ) {
 		return;
 	}
 

--- a/leaflet.geojsoncss.min.js
+++ b/leaflet.geojsoncss.min.js
@@ -1,6 +1,6 @@
 /**
  * Leaflet.geojsonCSS
- * @author Alexander Burtsev, http://burtsev.me, 2014
+ * @author Alexander Burtsev, http://burtsev.me, 2017
  * @license MIT
  */
-!function(a){a.L&&L.GeoJSON&&(L.GeoJSON.CSS=L.GeoJSON.extend({initialize:function(a,b){var c=L.extend({},b,{onEachFeature:function(a,c){b&&b.onEachFeature&&b.onEachFeature(a,c);var d=a.style,e=a.popupTemplate;d&&(c instanceof L.Marker?d.icon&&c.setIcon(L.icon(d.icon)):c.setStyle(d)),e&&a.properties&&c.bindPopup(L.Util.template(e,a.properties))}});L.setOptions(this,c),this._layers={},a&&this.addData(a)}}),L.geoJson.css=function(a,b){return new L.GeoJSON.CSS(a,b)})}(window,document);
+!function(a,b,c){"undefined"!=typeof L&&L.GeoJSON&&(L.GeoJSON.CSS=L.GeoJSON.extend({initialize:function(a,b){var c=L.extend({},b,{onEachFeature:function(a,c){b&&b.onEachFeature&&b.onEachFeature(a,c);var d=a.style,e=a.popupTemplate;d&&(c instanceof L.Marker?d.icon&&c.setIcon(L.icon(d.icon)):c.setStyle(d)),e&&a.properties&&c.bindPopup(L.Util.template(e,a.properties))}});L.setOptions(this,c),this._layers={},a&&this.addData(a)}}),L.geoJson.css=function(a,b){return new L.GeoJSON.CSS(a,b)})}(window,document);


### PR DESCRIPTION
When Leaflet is not exposed (e.g. when using Leaflet with RequireJs), `window.L` is not defined, but Leaflet might be available as plain `L` in the local scope.
To solve this issue, instead of checking if `window` has an `L` member, we can check the type of `L` to see if it's defined